### PR TITLE
refactor: use generics in ProducerRecord

### DIFF
--- a/dss/src/main/java/com/radiant/kafka/ProducerRecord.java
+++ b/dss/src/main/java/com/radiant/kafka/ProducerRecord.java
@@ -7,10 +7,12 @@ import java.util.List;
 import java.util.Map;
 
 public class ProducerRecord<V> implements Serializable {
-   private List<Map<String, Object>> records = new ArrayList();
+   private static final long serialVersionUID = 1L;
+
+   private List<Map<String, Object>> records = new ArrayList<>();
 
    public ProducerRecord(String key, V value) {
-      Map<String, Object> map = new HashMap();
+      Map<String, Object> map = new HashMap<String, Object>();
       if (key != null) {
          map.put("key", key);
       }


### PR DESCRIPTION
## Summary
- add serialVersionUID to ProducerRecord
- use generics for list and map to avoid raw type warnings

## Testing
- `mvn -pl dss -am -DskipTests compile` *(fails: Non-resolvable parent POM: network is unreachable)*
- `javac -Xlint:unchecked dss/src/main/java/com/radiant/kafka/ProducerRecord.java`
- `javac -Xlint:unchecked,serial dss/src/main/java/com/radiant/kafka/ProducerRecord.java` *(warns: non-serializable field type)*

------
https://chatgpt.com/codex/tasks/task_e_689da4e365a0832987835b0cf2e609e3