### PR TITLE
refactor: rename temporary variables

### DIFF
--- a/dss/src/main/java/com/radiant/program/service/DssProgramExecutionServiceImpl.java
+++ b/dss/src/main/java/com/radiant/program/service/DssProgramExecutionServiceImpl.java
@@ -93,7 +93,7 @@ public class DssProgramExecutionServiceImpl implements DssProgramExecutionServic
 
          try {
             dssProgram.dnodeExecute(request, response);
-         } catch (NotImplementedException var12) {
+         } catch (NotImplementedException notImplemented) {
             throw new DssExecuteNotImplemented("Method dnodeExecute not implemented for program " + programName);
          }
 
@@ -115,7 +115,7 @@ public class DssProgramExecutionServiceImpl implements DssProgramExecutionServic
 
          try {
             Files.delete(jar);
-         } catch (NoSuchFileException var6) {
+         } catch (NoSuchFileException e) {
             LOG.info("Program file not found for query {} while replacing", queryName);
          } catch (IOException e) {
             LOG.error("Failed to delete jar lib {}", jar.getFileName(), e);


### PR DESCRIPTION
## Summary
- rename temporary variables in `DssProgramExecutionServiceImpl` to be descriptive
- replace `var12` and `var6` with meaningful names

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_689da9708af08329af30cf953b0f5715