### PR TITLE
Refactor DbAccessServiceImpl resource handling

### DIFF
--- a/dss/src/main/java/com/radiant/dataConnector/service/DbAccessServiceImpl.java
+++ b/dss/src/main/java/com/radiant/dataConnector/service/DbAccessServiceImpl.java
@@ -43,108 +43,19 @@ public class DbAccessServiceImpl implements DbAccessService {
    private String driverDirectories;
 
    public boolean testConnection(JdbcDataConnector connector) {
-      try {
-         Connection connection = this.getConnection(connector);
-         Throwable var3 = null;
-
-         boolean var4;
-         try {
-            var4 = connection.getMetaData() != null;
-         } catch (Throwable var14) {
-            var3 = var14;
-            throw var14;
-         } finally {
-            if (connection != null) {
-               if (var3 != null) {
-                  try {
-                     connection.close();
-                  } catch (Throwable var13) {
-                     var3.addSuppressed(var13);
-                  }
-               } else {
-                  connection.close();
-               }
-            }
-
-         }
-
-         return var4;
+      try (Connection connection = this.getConnection(connector)) {
+         return connection.getMetaData() != null;
       } catch (SQLException e) {
          throw new JdbcException(connector.getHostname(), connector.getDbName(), connector.getDbVersion(), connector.getCustomJdbcUrl(), e);
       }
    }
 
    public String executeQueryForSingleString(JdbcDataConnector connector, String query) throws JdbcException {
-      try {
-         Connection con = this.getConnection(connector);
-         Throwable var4 = null;
-
-         Object var9;
-         try {
-            Statement stmt = con.createStatement();
-            Throwable var6 = null;
-
-            try {
-               ResultSet rs = stmt.executeQuery(query);
-               Throwable var8 = null;
-
-               try {
-                  rs.next();
-                  var9 = rs.getString(1);
-               } catch (Throwable var56) {
-                  var9 = var56;
-                  var8 = var56;
-                  throw var56;
-               } finally {
-                  if (rs != null) {
-                     if (var8 != null) {
-                        try {
-                           rs.close();
-                        } catch (Throwable var55) {
-                           var8.addSuppressed(var55);
-                        }
-                     } else {
-                        rs.close();
-                     }
-                  }
-
-               }
-            } catch (Throwable var58) {
-               var6 = var58;
-               throw var58;
-            } finally {
-               if (stmt != null) {
-                  if (var6 != null) {
-                     try {
-                        stmt.close();
-                     } catch (Throwable var54) {
-                        var6.addSuppressed(var54);
-                     }
-                  } else {
-                     stmt.close();
-                  }
-               }
-
-            }
-         } catch (Throwable var60) {
-            var4 = var60;
-            throw var60;
-         } finally {
-            if (con != null) {
-               if (var4 != null) {
-                  try {
-                     con.close();
-                  } catch (Throwable var53) {
-                     var4.addSuppressed(var53);
-                  }
-               } else {
-                  con.close();
-               }
-            }
-
-         }
-
-         return (String)var9;
+      try (Connection connection = this.getConnection(connector);
+           Statement stmt = connection.createStatement();
+           ResultSet resultSet = stmt.executeQuery(query)) {
+         resultSet.next();
+         return resultSet.getString(1);
       } catch (SQLException e) {
          throw new JdbcException(connector.getHostname(), connector.getDbName(), connector.getDbVersion(), connector.getCustomJdbcUrl(), e);
       }
@@ -152,77 +63,12 @@ public class DbAccessServiceImpl implements DbAccessService {
 
    public JSONArray executeQuery(JdbcDataConnector connector, String query) {
       LOG.info("Executing query: {}", query);
-
-      try {
-         Connection con = this.getConnection(connector);
-         Throwable var4 = null;
-
-         JSONArray var10;
-         try {
-            Statement stmt = con.createStatement(1004, 1007);
-            Throwable var6 = null;
-
-            try {
-               ResultSet rs = stmt.executeQuery(query);
-               Throwable var8 = null;
-
-               try {
-                  JSONArray jsonResult = this.readResultSet(rs);
-                  LOG.info("Query result: {}", jsonResult.toString(4));
-                  var10 = jsonResult;
-               } catch (Throwable var57) {
-                  var8 = var57;
-                  throw var57;
-               } finally {
-                  if (rs != null) {
-                     if (var8 != null) {
-                        try {
-                           rs.close();
-                        } catch (Throwable var56) {
-                           var8.addSuppressed(var56);
-                        }
-                     } else {
-                        rs.close();
-                     }
-                  }
-
-               }
-            } catch (Throwable var59) {
-               var6 = var59;
-               throw var59;
-            } finally {
-               if (stmt != null) {
-                  if (var6 != null) {
-                     try {
-                        stmt.close();
-                     } catch (Throwable var55) {
-                        var6.addSuppressed(var55);
-                     }
-                  } else {
-                     stmt.close();
-                  }
-               }
-
-            }
-         } catch (Throwable var61) {
-            var4 = var61;
-            throw var61;
-         } finally {
-            if (con != null) {
-               if (var4 != null) {
-                  try {
-                     con.close();
-                  } catch (Throwable var54) {
-                     var4.addSuppressed(var54);
-                  }
-               } else {
-                  con.close();
-               }
-            }
-
-         }
-
-         return var10;
+      try (Connection connection = this.getConnection(connector);
+           Statement stmt = connection.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
+           ResultSet resultSet = stmt.executeQuery(query)) {
+         JSONArray jsonResult = this.readResultSet(resultSet);
+         LOG.info("Query result: {}", jsonResult.toString(4));
+         return jsonResult;
       } catch (SQLException e) {
          throw new JdbcException(connector.getHostname(), connector.getDbName(), connector.getDbVersion(), connector.getCustomJdbcUrl(), e);
       }
@@ -230,121 +76,32 @@ public class DbAccessServiceImpl implements DbAccessService {
 
    public JSONObject executeQuery(JdbcDataConnector connector, String query, Integer pageSize, Integer pageNum) {
       LOG.info("Executing query: {}", query);
-
-      try {
-         Connection con = this.getConnection(connector);
-         Throwable var6 = null;
-
-         JSONObject var14;
-         try {
-            Statement stmt = con.createStatement(1004, 1007);
-            Throwable var8 = null;
-
-            try {
-               ResultSet rs = stmt.executeQuery(query);
-               Throwable var10 = null;
-
-               try {
-                  rs.last();
-                  int rowsCount = rs.getRow();
-                  rs.beforeFirst();
-                  CachedRowSet crs = RowSetProvider.newFactory().createCachedRowSet();
-                  crs.setPageSize(pageSize);
-                  crs.populate(rs, pageSize * (pageNum - 1) + 1);
-                  JSONObject pagingWrapping = new JSONObject();
-                  pagingWrapping.put("page", pageNum);
-                  pagingWrapping.put("pageSize", pageSize);
-                  pagingWrapping.put("total", rowsCount);
-                  pagingWrapping.put("data", this.readResultSet(crs));
-                  LOG.info("Paged query result: {}", pagingWrapping.toString(4));
-                  var14 = pagingWrapping;
-               } catch (Throwable var61) {
-                  var10 = var61;
-                  throw var61;
-               } finally {
-                  if (rs != null) {
-                     if (var10 != null) {
-                        try {
-                           rs.close();
-                        } catch (Throwable var60) {
-                           var10.addSuppressed(var60);
-                        }
-                     } else {
-                        rs.close();
-                     }
-                  }
-
-               }
-            } catch (Throwable var63) {
-               var8 = var63;
-               throw var63;
-            } finally {
-               if (stmt != null) {
-                  if (var8 != null) {
-                     try {
-                        stmt.close();
-                     } catch (Throwable var59) {
-                        var8.addSuppressed(var59);
-                     }
-                  } else {
-                     stmt.close();
-                  }
-               }
-
-            }
-         } catch (Throwable var65) {
-            var6 = var65;
-            throw var65;
-         } finally {
-            if (con != null) {
-               if (var6 != null) {
-                  try {
-                     con.close();
-                  } catch (Throwable var58) {
-                     var6.addSuppressed(var58);
-                  }
-               } else {
-                  con.close();
-               }
-            }
-
-         }
-
-         return var14;
+      try (Connection connection = this.getConnection(connector);
+           Statement stmt = connection.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
+           ResultSet resultSet = stmt.executeQuery(query)) {
+         resultSet.last();
+         int rowsCount = resultSet.getRow();
+         resultSet.beforeFirst();
+         CachedRowSet crs = RowSetProvider.newFactory().createCachedRowSet();
+         crs.setPageSize(pageSize);
+         crs.populate(resultSet, pageSize * (pageNum - 1) + 1);
+         JSONObject pagingWrapping = new JSONObject();
+         pagingWrapping.put("page", pageNum);
+         pagingWrapping.put("pageSize", pageSize);
+         pagingWrapping.put("total", rowsCount);
+         pagingWrapping.put("data", this.readResultSet(crs));
+         LOG.info("Paged query result: {}", pagingWrapping.toString(4));
+         return pagingWrapping;
       } catch (SQLException e) {
          throw new JdbcException(connector.getHostname(), connector.getDbName(), connector.getDbVersion(), connector.getCustomJdbcUrl(), e);
       }
    }
 
    public String getVersion(JdbcDataConnector connector) {
-      try {
-         Connection connection = this.getConnection(connector);
-         Throwable var3 = null;
-
-         String var5;
-         try {
-            DatabaseMetaData meta = connection.getMetaData();
-            var5 = meta.getDatabaseProductName() + " " + meta.getDatabaseProductVersion();
-         } catch (Throwable var15) {
-            var3 = var15;
-            throw var15;
-         } finally {
-            if (connection != null) {
-               if (var3 != null) {
-                  try {
-                     connection.close();
-                  } catch (Throwable var14) {
-                     var3.addSuppressed(var14);
-                  }
-               } else {
-                  connection.close();
-               }
-            }
-
-         }
-
-         return var5;
-      } catch (SQLException var17) {
+      try (Connection connection = this.getConnection(connector)) {
+         DatabaseMetaData metadata = connection.getMetaData();
+         return metadata.getDatabaseProductName() + " " + metadata.getDatabaseProductVersion();
+      } catch (SQLException e) {
          return null;
       }
    }


### PR DESCRIPTION
## Summary
- simplify database access service by replacing decompiler variables with descriptive names
- use try-with-resources for Connection, Statement, and ResultSet

## Testing
- `mvn -q -pl dss -am test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689da973fd1c83299b36407a6ecb5032