### PR TITLE
chore: rename ambiguous variables

### DIFF
--- a/dss/src/main/java/com/radiant/query/service/QueryExecutionServiceImpl.java
+++ b/dss/src/main/java/com/radiant/query/service/QueryExecutionServiceImpl.java
@@ -78,9 +78,8 @@ public class QueryExecutionServiceImpl implements QueryExecutionService {
             case SQL:
                Set<Long> executeDcId = (Set)courtLinkedConnectors.stream().map(DataConnector::getId).collect(Collectors.toSet());
                List<QueryImplConnectorDto> executionNamedDcList = (List)testExecutionDto.getNamedConnectors().stream().filter((namedDc) -> {
-                  Stream var10000 = namedDc.getDataConnectors().stream();
-                  executeDcId.getClass();
-                  return var10000.anyMatch(executeDcId::contains);
+                  Stream<Long> dcIdStream = namedDc.getDataConnectors().stream();
+                  return dcIdStream.anyMatch(executeDcId::contains);
                }).collect(Collectors.toList());
                if (executionNamedDcList.isEmpty()) {
                   throw new IllegalStateException("Query impl data connectors don't match to court data connectors");

--- a/gdds/src/main/java/com/radiant/court/service/GddsCourtServiceImpl.java
+++ b/gdds/src/main/java/com/radiant/court/service/GddsCourtServiceImpl.java
@@ -438,9 +438,12 @@ public class GddsCourtServiceImpl implements GddsCourtService {
    private CourtTreeNode getCourtTree(List<GddsRegion> allRegions, GddsRegion region, Map<Long, List<RegionCourt>> courtsByRegion) {
       CourtTreeNode node = GddsCourtUtils.createLeafNode(region);
       if (courtsByRegion.containsKey(region.getId())) {
-         Stream var10000 = ((List)courtsByRegion.get(region.getId())).stream().sorted(Comparator.comparing(RegionCourt::getOrder)).map(RegionCourt::getCourt).map(GddsCourtUtils::createLeafNode);
-         List var10001 = node.getChildren();
-         var10000.forEach(var10001::add);
+         Stream<CourtTreeNode> courtNodeStream = ((List<RegionCourt>)courtsByRegion.get(region.getId())).stream()
+            .sorted(Comparator.comparing(RegionCourt::getOrder))
+            .map(RegionCourt::getCourt)
+            .map(GddsCourtUtils::createLeafNode);
+         List<CourtTreeNode> children = node.getChildren();
+         courtNodeStream.forEach(children::add);
       }
 
       List<GddsRegion> subRegions = (List)allRegions.stream().filter((c) -> c.getParent() != null && c.getParent().getId().equals(region.getId())).collect(Collectors.toList());

--- a/gdds/src/main/java/com/radiant/program/domain/SendProgramToDss.java
+++ b/gdds/src/main/java/com/radiant/program/domain/SendProgramToDss.java
@@ -67,7 +67,7 @@ public class SendProgramToDss extends ProgramStage {
       } else {
          for(String dssUrl : request.getCustomDnodeUrl()) {
             allDNodes.stream().filter((dss) -> dssUrl != null && dssUrl.equalsIgnoreCase(dss.getDnodeUrl())).findFirst().ifPresent((foundDss) -> {
-               DNode var10000 = (DNode)baseDss.putIfAbsent(dssUrl, foundDss);
+               DNode existingDNode = baseDss.putIfAbsent(dssUrl, foundDss);
             });
          }
       }

--- a/gdds/src/main/java/com/radiant/program/registry/ProgramJarLoader.java
+++ b/gdds/src/main/java/com/radiant/program/registry/ProgramJarLoader.java
@@ -57,17 +57,17 @@ public class ProgramJarLoader extends JarContentLoader {
    }
 
    private RdsmProgram findEchoProgramAnnotation(Set<? extends Class<?>> klasses) {
-      Stream var10000 = klasses.stream();
+      Stream<Class<?>> classesStream = klasses.stream();
       QnodeProgramAdapter.class.getClass();
-      Optional<? extends Class<?>> gddsAnnotatedClass = var10000.filter(QnodeProgramAdapter.class::isAssignableFrom).findAny();
+      Optional<? extends Class<?>> gddsAnnotatedClass = classesStream.filter(QnodeProgramAdapter.class::isAssignableFrom).findAny();
       if (gddsAnnotatedClass.isPresent()) {
          RdsmProgram annotation = (RdsmProgram)((Class)gddsAnnotatedClass.get()).getAnnotation(RdsmProgram.class);
          LOG.trace("Echo program annotation detected {}", annotation);
          return annotation;
       } else {
-         var10000 = klasses.stream();
+         classesStream = klasses.stream();
          DnodeProgramAdapter.class.getClass();
-         Optional<? extends Class<?>> dssAnnotatedClass = var10000.filter(DnodeProgramAdapter.class::isAssignableFrom).findAny();
+         Optional<? extends Class<?>> dssAnnotatedClass = classesStream.filter(DnodeProgramAdapter.class::isAssignableFrom).findAny();
          if (dssAnnotatedClass.isPresent()) {
             RdsmProgram annotation = (RdsmProgram)((Class)dssAnnotatedClass.get()).getAnnotation(RdsmProgram.class);
             LOG.trace("Echo program annotation detected {}", annotation);


### PR DESCRIPTION
## Summary
- rename autogenerated `var10000` variables to descriptive names across services
- streamline court tree creation by using named streams
- clarify connector filtering in query test execution

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_689da97432188329bb3eaedb93fb7bba